### PR TITLE
Hikari cp 6x updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>io.volcanolabs</groupId>
 	<artifactId>rds-iam-hikari-datasource</artifactId>
-	<version>3.1.0</version>
+	<version>3.2.0</version>
 	<name>rds-iam-hikari-datasource</name>
 	<description>
 		An extension to the Hikari datasource for IAM Role based access to RDS databases. This is entirely based on the
@@ -48,14 +48,14 @@
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-dependencies</artifactId>
-				<version>3.4.0</version>
+				<version>3.5.0</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
 			<dependency>
 				<groupId>software.amazon.awssdk</groupId>
 				<artifactId>bom</artifactId>
-				<version>2.29.35</version>
+				<version>2.31.63</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/src/main/java/io/volcanolabs/rds/RdsIamHikariDataSource.java
+++ b/src/main/java/io/volcanolabs/rds/RdsIamHikariDataSource.java
@@ -4,7 +4,7 @@ import com.zaxxer.hikari.util.Credentials;
 import com.zaxxer.hikari.HikariDataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.auth.credentials.WebIdentityTokenFileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 import software.amazon.awssdk.services.rds.RdsUtilities;
@@ -51,7 +51,7 @@ public class RdsIamHikariDataSource extends HikariDataSource {
 				.build();
 
 		RdsUtilities utilities = RdsUtilities.builder()
-				.credentialsProvider( WebIdentityTokenFileCredentialsProvider.create() )
+				.credentialsProvider( DefaultCredentialsProvider.builder().build() )
 				.region( region )
 				.build();
 

--- a/src/main/java/io/volcanolabs/rds/RdsIamHikariDataSource.java
+++ b/src/main/java/io/volcanolabs/rds/RdsIamHikariDataSource.java
@@ -1,9 +1,10 @@
 package io.volcanolabs.rds;
 
+import com.zaxxer.hikari.util.Credentials;
 import com.zaxxer.hikari.HikariDataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.WebIdentityTokenFileCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 import software.amazon.awssdk.services.rds.RdsUtilities;
@@ -21,6 +22,12 @@ public class RdsIamHikariDataSource extends HikariDataSource {
 
 	public RdsIamHikariDataSource() {
 		log.trace( "RdsIamHikariDataSource created" );
+	}
+
+	@Override
+	public Credentials getCredentials() {
+		log.trace( "RdsIamHikariDataSource.getCredentials() called." );
+		return Credentials.of(getUsername(), getToken());
 	}
 
 	@Override
@@ -44,7 +51,7 @@ public class RdsIamHikariDataSource extends HikariDataSource {
 				.build();
 
 		RdsUtilities utilities = RdsUtilities.builder()
-				.credentialsProvider( DefaultCredentialsProvider.create() )
+				.credentialsProvider( WebIdentityTokenFileCredentialsProvider.create() )
 				.region( region )
 				.build();
 


### PR DESCRIPTION
## POM 
 - Updated Spring Boot dependencies version
 - Updated AWS SDK 
 - Increase Minor Version

## RdsHikariDataSource
 - HikariCP 6.x introduced the Credentials Object. getPassword() does not get called after updating to Spring Boot 3.5
 - https://github.com/brettwooldridge/HikariCP/issues/2256#issuecomment-2908940501