### PR TITLE
AWS SDK Bump

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>io.volcanolabs</groupId>
 	<artifactId>rds-iam-hikari-datasource</artifactId>
-	<version>3.2.1</version>
+	<version>3.2.2</version>
 	<name>rds-iam-hikari-datasource</name>
 	<description>
 		An extension to the Hikari datasource for IAM Role based access to RDS databases. This is entirely based on the
@@ -55,7 +55,7 @@
 			<dependency>
 				<groupId>software.amazon.awssdk</groupId>
 				<artifactId>bom</artifactId>
-				<version>2.32.24</version>
+				<version>2.32.25</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -85,12 +85,6 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-autoconfigure</artifactId>
 		</dependency>
-
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec</artifactId>
-            <version>4.1.124.Final</version>
-        </dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
The Netty dependency was updated in the new verision of the AWS sdk.
[See release here](https://github.com/aws/aws-sdk-java-v2/releases/tag/2.32.25)

this PR is bumping the AWS SDK dependency version and removing the duplicate netty dependency.

This will help resolve outstanding scan issues due to the old version of the aws sdk having an older version of netty